### PR TITLE
Automatically expand if there's only one device

### DIFF
--- a/files/kdecapplet@joejoetv/applet.js
+++ b/files/kdecapplet@joejoetv/applet.js
@@ -309,7 +309,8 @@ KDEConnectApplet.prototype = {
     },
 
     on_applet_clicked: function() {
-		this.menu.toggle();
+        if (this.onlyOneDevice) this.menu.firstMenuItem.menu.open(false);
+        this.menu.toggle();
     },
 
     on_applet_removed_from_panel: function() {
@@ -344,6 +345,7 @@ KDEConnectApplet.prototype = {
         try {
             deviceIDs = this.kdecProxy.devicesSync(true, true)[0];
             deviceNames = this.kdecProxy.deviceNamesSync(true, true)[0];
+            this.onlyOneDevice = deviceIDs.length == 1;
         }
         catch (error) {
             global.logError(error);


### PR DESCRIPTION
Thanks for this applet - it's way more polished than the one in the applet repo.
This PR automatically expands a device if it's the only one added.